### PR TITLE
Fixing the build / template resolution issues in oauth1.cpp

### DIFF
--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,14 +1,12 @@
 {
   "s": [
-    "Release/include/", 
+    "Release/include/",
     "Release/src",
-    "Release/src/pch", 
+    "Release/src/pch",
     "Release/src/utilities/"
   ],
-  "x": [
-
-  ],
-  "x:clang-cxx17" : [
+  "x": [],
+  "x:clang-cxx17": [
     "Release/src/http/client/http_client_winhttp.cpp",
     "Release/src/http/client/http_client_winrt.cpp",
     "Release/src/http/listener/http_server_httpsys.cpp",
@@ -22,7 +20,7 @@
     "Release/samples",
     "vcpkg"
   ],
-  "x:macos" : [
+  "x:macos": [
     "Release/src/http/client/http_client_winhttp.cpp",
     "Release/src/http/client/http_client_winrt.cpp",
     "Release/src/http/listener/http_server_httpsys.cpp",
@@ -119,34 +117,65 @@
     "Release/tests",
     "Release/samples",
     "vcpkg"
-  ]
-
-  , "nxxm/brotli" : {
-      "s" : ["c/include", "c/common", "c/enc", "c/dec"]
-    }
-
-
-  , "nxxm/boringssl" : { "@" : ":64b173d5c7acb7e8e270997418685d9a00f0537b",
-      "u": true
-      , "packages" : ["OpenSSL"]
-      , "targets" : ["OpenSSL::SSL", "OpenSSL::Crypto"]
-      , "find_mode" : "MODULE"
-  }
-
-  , "hunter-packages/zlib" : { 
-    "@" : "v1.2.11-p1"
-    , "u" : true
-    , "packages" : ["ZLIB"]
-    , "targets" : ["ZLIB::zlib"]
-  }
-
-  , "boostorg/boost" : { "@" : "boost-1.80.0",
+  ],
+  "requires": {
+    "boostorg/boost": {
+      "@": "boost-1.80.0",
       "opts": "set(BOOST_INCLUDE_LIBRARIES system filesystem uuid)",
-      "packages": [ "boost_system", "boost_filesystem", "boost_uuid" ],
-      "targets": [ "Boost::system", "Boost::filesystem", "Boost::uuid" ],
+      "packages": [
+        "boost_system",
+        "boost_filesystem",
+        "boost_uuid"
+      ],
+      "targets": [
+        "Boost::system",
+        "Boost::filesystem",
+        "Boost::uuid"
+      ],
       "u": true
-  } 
-
-  , "platform:vs-16-2019-win64-cxx17" : ["target::crypt32"]
-  , "platform:vs-15-2017-win64-cxx17" : ["target::crypt32"]
+    },
+    "hunter-packages/zlib": {
+      "@": "v1.2.11-p1",
+      "packages": [
+        "ZLIB"
+      ],
+      "targets": [
+        "ZLIB::zlib"
+      ],
+      "u": true
+    },
+    "google/boringssl": {
+      "@": ":f896fbd7a94daf801446ae997d288e7f03a5d9a2",
+      "find_mode": "MODULE",
+      "packages": [
+        "OpenSSL"
+      ],
+      "targets": [
+        "OpenSSL::SSL",
+        "OpenSSL::Crypto"
+      ],
+      "opts": "set(BUILD_SHARED_LIBS OFF CACHE BOOL \"only static libs\" FORCE)\nset(CMAKE_CXX_FLAGS \"${CMAKE_CXX_FLAGS} -Wno-error=unused-command-line-argument\")\nset(CMAKE_EXE_LINKER_FLAGS \"${CMAKE_EXE_LINKER_FLAGS} -Wno-error=unused-command-line-argument\")",
+      "u": true
+    },
+    "nxxm/brotli": {
+      "s": [
+        "c/include",
+        "c/common",
+        "c/enc",
+        "c/dec"
+      ],
+      "x": [
+        "/research",
+        "/c/fuzz",
+        "/c/tools"
+      ],
+      "u": false
+    }
+  },
+  "platform:vs-16-2019-win64-cxx17": [
+    "target::crypt32"
+  ],
+  "platform:vs-15-2017-win64-cxx17": [
+    "target::crypt32"
+  ]
 }

--- a/Release/src/http/oauth/oauth1.cpp
+++ b/Release/src/http/oauth/oauth1.cpp
@@ -15,6 +15,15 @@
 
 #include "cpprest/asyncrt_utils.h"
 
+
+#if defined(_WIN32) && !defined(__cplusplus_winrt) // Windows desktop
+// nothing
+#elif defined(_WIN32) && defined(__cplusplus_winrt) // Windows RT
+// nothing
+#else
+#include <openssl/hmac.h>
+#endif
+
 #if _WIN32_WINNT >= _WIN32_WINNT_VISTA
 
 using namespace utility;
@@ -132,7 +141,6 @@ std::vector<unsigned char> oauth1_config::_hmac_sha1(const utility::string_t& ke
 
 #else // Linux, Mac OS X
 
-#include <openssl/hmac.h>
 
 std::vector<unsigned char> oauth1_config::_hmac_sha1(const utility::string_t& key, const utility::string_t& data)
 {


### PR DESCRIPTION
some changes in the updated boringssl's `hmac.h` were causing template resolution issues because clang is quite strict.